### PR TITLE
fix: match URP/HDRP depth scalar to Standard RP and web compositor

### DIFF
--- a/Addons~/io.conix.arena.renderfusion-hdrp/Runtime/Resources/RGBDepthHDRP.shader
+++ b/Addons~/io.conix.arena.renderfusion-hdrp/Runtime/Resources/RGBDepthHDRP.shader
@@ -64,7 +64,7 @@ Shader "Hidden/RGBDepthHDRP"
                         float xCoord = (i.uv.x - 0.5) + 0.25;
                         float2 positionSS = float2(xCoord, i.uv.y) * _ScreenSize.xy;
                         float depth = LoadCameraDepth(positionSS);
-                        depth = 5 * Linear01Depth(depth, _ZBufferParams);
+                        depth = 50 * Linear01Depth(depth, _ZBufferParams);
                         col.rgb = depth;
                     }
                 }
@@ -95,7 +95,7 @@ Shader "Hidden/RGBDepthHDRP"
                         float xCoord = i.uv.x - 0.5;
                         float2 positionSS = float2(0.25 + xCoord, i.uv.y) * _ScreenSize.xy;
                         float depth = LoadCameraDepth(positionSS);
-                        depth = 5 * Linear01Depth(depth, _ZBufferParams);
+                        depth = 50 * Linear01Depth(depth, _ZBufferParams);
                         col.rgb = depth;
                     }
                 }

--- a/Addons~/io.conix.arena.renderfusion-urp/Runtime/Resources/RGBDepthURP.shader
+++ b/Addons~/io.conix.arena.renderfusion-urp/Runtime/Resources/RGBDepthURP.shader
@@ -43,7 +43,7 @@ Shader "Hidden/RGBDepthURP"
                         float xCoord = input.texcoord.x - 0.5;
                         float2 uv = float2(0.25 + xCoord, input.texcoord.y);
                         float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, sampler_CameraDepthTexture, uv);
-                        depth = 5 * Linear01Depth(depth, _ZBufferParams);
+                        depth = 50 * Linear01Depth(depth, _ZBufferParams);
                         col.rgb = depth;
                     }
                 }
@@ -74,7 +74,7 @@ Shader "Hidden/RGBDepthURP"
                         float xCoord = input.texcoord.x - 0.5;
                         float2 uv = float2(0.25 + xCoord, input.texcoord.y);
                         float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, sampler_CameraDepthTexture, uv);
-                        depth = 5 * Linear01Depth(depth, _ZBufferParams);
+                        depth = 50 * Linear01Depth(depth, _ZBufferParams);
                         col.rgb = depth;
                     }
                 }


### PR DESCRIPTION
The URP and HDRP RGBDepth shaders encoded linearized depth with a 5× scalar, but the web compositor's fragment shader divides by DEPTH_SCALAR (50.0) — the value the Standard RP shader uses. The 10× mismatch caused three visual artifacts reported in #26:

  - skybox circle artifact (depth half of frame bleeding into color)
  - screen-space block/jagged artifacts at geometry edges
  - green depth band and texture glitches at distance

Change all four depth encoding sites (single + dual camera paths for both URP and HDRP) from 5× to 50× to match the Standard RP shader and the web compositor expectation.

Fixes #26